### PR TITLE
display name correctly when not unlocked, fix initial magicball

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -604,7 +604,7 @@
                         <div class="row justify-content-sm-center">
                             <div style="height:20px;" class="col">
                                 <b>
-                                    <span data-bind="text: OakItemRunner.inspectedItem().name()"></span>
+                                    <span data-bind="text: OakItemRunner.inspectedItem().displayName()"></span>
                                 </b>
                             </div>
                         </div>

--- a/src/scripts/oakitems/OakItemRunner.ts
+++ b/src/scripts/oakitems/OakItemRunner.ts
@@ -2,8 +2,8 @@ class OakItemRunner {
 
     public static oakItemList: KnockoutObservable<OakItem>[];
     // public static blankOakItem: OakItem = new OakItem(" ", Number.MAX_VALUE, "", 0, 0, 0);
-    public static inspectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 30, "Gives a bonus to your catchrate", 5, 1, 2));
-    public static selectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 30, "Gives a bonus to your catchrate", 5, 1, 2));
+    public static inspectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2));
+    public static selectedItem: KnockoutObservable<OakItem> = ko.observable(new OakItem(GameConstants.OakItem.MagicBall, "Magic Ball", 20, "Gives a bonus to your catchrate", 5, 1, 2));
 
     public static initialize() {
         OakItemRunner.oakItemList = [];


### PR DESCRIPTION
Fixes the name shown when you have not unlocked an oak item,
Also set correct unlock level for initial oak item.

**Note:** Merging into the `oak-const` branch, to go with https://github.com/Ishadijcks/pokeclicker/pull/302