### PR TITLE
Show current quest progress on progress bar, Hide quest list until tutorial complete

### DIFF
--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -3,7 +3,7 @@ style="background-color: white; min-height: 100px">
 
     <!-- Quests header -->
     <h6 style="display:inline">
-        <span class='' data-bind='text: "Quests (" + player.currentQuests().length + "/" + QuestHelper.questSlots()() + ")"'>
+        <span class='' data-bind='text: !player.tutorialComplete() ? "Tutorial Quest" : "Quests (" + player.currentQuests().length + "/" + QuestHelper.questSlots()() + ")"'>
         </span>
     </h6>
     <button class='btn btn-sm btn-primary' style="margin:5px"

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -7,7 +7,7 @@ style="background-color: white; min-height: 100px">
         </span>
     </h6>
     <button class='btn btn-sm btn-primary' style="margin:5px"
-            data-bind='click: function(){$("#QuestModal").modal("show")}'>
+            data-bind='visible: player.tutorialComplete(), click: function(){$("#QuestModal").modal("show")}'>
         Quest List
     </button>
 

--- a/src/components/questDisplay.html
+++ b/src/components/questDisplay.html
@@ -14,44 +14,53 @@ style="background-color: white; min-height: 100px">
     <!-- List of quests -->
     <div data-bind="foreach: player.currentQuests">
         <div class="card border-bottom-0">
-            <p style="margin-bottom: 0px" data-bind="text: QuestHelper.questList()[$data.index].description"></p>
-            <div class="row justify-content-sm-center">
-                <div class="col-sm-11 col-md-8">
-                    <div class="row" style="margin-bottom: 10px">
-                        <div class="col-9" style="padding:0px; margin:0px">
-                            <div class="progress" style="margin-top:6px; padding:0px; text-align:center" 
-                                data-bind='tooltip: {title: QuestHelper.questList()[$data.index].progressText, trigger: "hover"}'>
-                                <div class="progress-bar bg-success" role="progressbar" 
-                                    data-bind="attr:{style: 'width:' + (QuestHelper.questList()[$data.index].progress() * 100) + '%'}"
-                                    aria-valuemin="0" aria-valuemax="100">
-                                </div>
+            <table>
+                <tr class="text-center">
+                    <td colspan="2" data-bind="text: QuestHelper.questList()[$data.index].description"></td>
+                </tr>
+                <tr>
+                    <td class="p-2">
+                        <div class="progress p-0">
+                            <div class="progress-bar bg-success" role="progressbar"
+                                data-bind="attr:{ style: 'width:' + (QuestHelper.questList()[$data.index].progress() * 100) + '%'}"
+                                aria-valuemin="0" aria-valuemax="100">
+                                <span data-bind="text: QuestHelper.questList()[$data.index].progressText">0/1000</span>
                             </div>
                         </div>
-                        <div class="col-3">
-                            <button style="margin:0px; padding:0px; height:20px; min-width:60px"
-                                    data-bind='
-                                        click: function(){QuestHelper.questList()[$data.index].exit();}, 
-                                        text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit", 
-                                        attr: {class: QuestHelper.questList()[$data.index].isCompleted() ? "btn btn-sm btn-success" : "btn btn-sm btn-danger"}'>  
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
+                    </td>
+                    <td width="30%" class="p-2">
+                        <button class="btn btn-sm btn-block p-0"
+                                data-bind='
+                                    click: function(){QuestHelper.questList()[$data.index].exit();},
+                                    text: QuestHelper.questList()[$data.index].isCompleted() ? "Claim" : "Quit",
+                                    css: {
+                                      "btn-success": QuestHelper.questList()[$data.index].isCompleted(),
+                                      "btn-danger": !QuestHelper.questList()[$data.index].isCompleted(),
+                                    }'>
+                        </button>
+                    </td>
+                </tr>
+            </table>
         </div>
     </div>
     <div data-bind='if: (!player.tutorialComplete()) && (QuestLineHelper.tutorial.totalQuests > 0) && (QuestLineHelper.tutorial.curQuest() < QuestLineHelper.tutorial.totalQuests)'>
-        <p data-bind='text: QuestLineHelper.tutorial.curQuestObject().description'></p>
-        <div class="row justify-content-center">
-            <div class="col-10">
-                <div class="progress"
-                     data-bind='tooltip: {title: ko.pureComputed(function(){return QuestLineHelper.tutorial.curQuestObject().progressText()}), trigger: "hover"}'>
-                    <div class="progress-bar bg-success" role="progressbar"
-                         data-bind="attr:{ style: 'width:' + (QuestLineHelper.tutorial.curQuestObject().progress() * 100) + '%' }"
-                         aria-valuemin="0" aria-valuemax="100">
-                    </div>
-                </div>
-            </div>
+        <div class="card border-bottom-0">
+            <table>
+                <tr class="text-center">
+                    <td data-bind="text: QuestLineHelper.tutorial.curQuestObject().description"></td>
+                </tr>
+                <tr>
+                    <td class="p-2">
+                        <div class="progress p-0">
+                            <div class="progress-bar bg-success" role="progressbar"
+                                data-bind="attr:{ style: 'width:' + (QuestLineHelper.tutorial.curQuestObject().progress() * 100) + '%'}"
+                                aria-valuemin="0" aria-valuemax="100">
+                                <span data-bind="text: ko.pureComputed(function(){return QuestLineHelper.tutorial.curQuestObject().progressText()})">0/1000</span>
+                            </div>
+                        </div>
+                    </td>
+                </tr>
+            </table>
         </div>
     </div>
 </div>

--- a/src/styles/quest.less
+++ b/src/styles/quest.less
@@ -17,3 +17,17 @@
 .questReward {
   vertical-align: middle;
 }
+
+#questDisplayContainer {
+  .progress {
+    position: relative;
+  }
+  .progress .progress-bar span {
+    text-align: center;
+    position: absolute;
+    display: block;
+    color:#333;
+    width: 100%;
+    line-height: 1rem;
+  }
+}


### PR DESCRIPTION
**Note:** Merging into the `quest-multi` branch, as companion of https://github.com/Ishadijcks/pokeclicker/pull/339


- [x] hide `quest list` button until tutorial completed:
- [x] show `tutorial quest` in title until tutorial completed:
![Screenshot from 2019-06-05 13-04-38](https://user-images.githubusercontent.com/7288322/58923167-98338900-8792-11e9-8ae2-72589c47f7c9.png)

- [x] show the current quest progress in the progress bar rather than in a tooltip:
![Screenshot from 2019-06-05 12-09-51](https://user-images.githubusercontent.com/7288322/58921439-dc229000-878a-11e9-8b6d-211f6fbd2837.png)

Or if you would prefer it to show the percentage instead:
**Edit:** The percentage makes it seem a bit too vague for this, as it is usually exact numbers you are after.
![Screenshot from 2019-06-05 12-11-58](https://user-images.githubusercontent.com/7288322/58921494-29066680-878b-11e9-8731-1add415bd0b6.png)
